### PR TITLE
Mobile friendly menu for the backend.

### DIFF
--- a/app/blueprints/account/templates/account/new-proposal.html
+++ b/app/blueprints/account/templates/account/new-proposal.html
@@ -1,7 +1,7 @@
 {% extends 'global/extends/backend.html' %}
 
 {% block title %}
-    New proposal
+    New Proposal
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/blueprints/account/templates/account/proposal.html
+++ b/app/blueprints/account/templates/account/proposal.html
@@ -1,7 +1,7 @@
 {% extends 'global/extends/backend.html' %}
 
 {% block title %}
-    Edit - {{ proposal.title }}
+    Editing Proposal: {{ proposal.title }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/blueprints/account/templates/account/update-feed.html
+++ b/app/blueprints/account/templates/account/update-feed.html
@@ -1,7 +1,7 @@
 {% extends 'global/extends/backend.html' %}
 
 {% block title %}
-    Account Update Feed
+    Update Feed
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/blueprints/account/templates/account/view-proposal.html
+++ b/app/blueprints/account/templates/account/view-proposal.html
@@ -1,7 +1,7 @@
 {% extends 'global/extends/backend.html' %}
 
 {% block title %}
-    View - {{ proposal.title }}
+    Viewing Proposal: {{ proposal.title }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/global/flask/context_processors.py
+++ b/app/global/flask/context_processors.py
@@ -24,9 +24,9 @@ def breadcrumber_processor():
         markup = ""
         for name, url in list_of_urls:
             if url is None:
-                markup += f'{name} / '
+                markup += f'/ {name} / '
             else:
-                markup += f'<a href="{url}">{name}</a> / '
+                markup += f'/ <a href="{url}">{name}</a> '
 
         return Markup(f"<strong>{markup[:-3]}</strong>")
 

--- a/app/global/static/flaskcon.css
+++ b/app/global/static/flaskcon.css
@@ -80,9 +80,23 @@
     text-align: center;
 }
 
+.fc-header {
+    background-color: rgba(255, 255, 255, 0.95);
+    position: fixed;
+    width: 100%;
+    z-index: 99;
+}
+
+.breadcrumbs {
+    font-size: 1rem;
+    padding-bottom: 1rem;
+    padding-left: 1rem;
+}
+
 .fc-container {
     display: flex;
     flex-direction: row;
+    padding-top: 80px;
 }
 
 .fc-container > aside {
@@ -94,8 +108,16 @@
     overflow-y: auto;
 }
 
+.backend-menu-hide {
+    margin-left: -290px;
+}
+
+.backend-menu-show {
+    margin-left: 0;
+}
+
 .dummy-side-nav {
-    display: block;
+    display: none;
     width: 250px;
     padding: 0 2rem;
 }
@@ -103,7 +125,7 @@
 .side-nav {
     display: block;
     width: 250px;
-    padding: 0 2rem;
+    padding: 2rem 2rem 3rem 2rem;
     text-align: center;
 }
 
@@ -200,7 +222,7 @@
 
 .content {
     flex: 1;
-    margin: 0 2rem;
+    margin: 2rem;
 }
 
 .content-box {
@@ -475,6 +497,10 @@
         flex-direction: row;
         justify-content: start;
         align-items: center;
+    }
+
+    .dummy-side-nav {
+        display: block;
     }
 }
 

--- a/app/global/templates/global/extends/backend.html
+++ b/app/global/templates/global/extends/backend.html
@@ -26,7 +26,8 @@
 
 </head>
 
-<body x-data>
+<body x-data="backend">
+
 <a id="top"></a>
 
 
@@ -52,9 +53,40 @@
 {% endif %}
 
 
-<div class="fc-container">
+<header class="fc-header">
+    <nav class="top-nav">
+        <div class="flex justify-center align-items-center gap-1">
+            <div x-cloak x-show="$store.backend_store.show_side_menu">
+                <button @click="$store.backend_store.show_side_menu_false()"
+                        class="m-all-0 p-all-0 p-left-right-1 flex align-items-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                         class="feather feather-chevron-left">
+                        <polyline points="15 18 9 12 15 6"></polyline>
+                    </svg>
+                </button>
+            </div>
+            <div x-cloak x-show="!$store.backend_store.show_side_menu">
+                <button @click="$store.backend_store.show_side_menu_true()"
+                        class="m-all-0 p-all-0 p-left-right-1 flex align-items-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                         class="feather feather-chevron-right">
+                        <polyline points="9 18 15 12 9 6"></polyline>
+                    </svg>
+                </button>
+            </div>
+            <h3 class="m-all-0">{{ self.title() }}</h3>
+        </div>
+        <a href="/" class="flex align-items-center p-left-right-1">
+            <img width="100px" src="{{ url_for('static', filename='flaskcon-logo.svg') }}" alt="">
+        </a>
+    </nav>
+</header>
 
-    <aside>
+<div class="fc-container">
+    <aside :class="$store.backend_store.show_side_menu ? 'backend-menu-show' : 'backend-menu-hide'">
+
         <div class="accountlet">
             <img width="200"
                  src="{{ url_for('static', filename='display-pictures/' + ctp_display_picture(session.get('unique_display_picture_id', 1))) }}"
@@ -62,9 +94,10 @@
             <p>{{ __account__.rel_profile.name_or_alias or __account__.email_address.split('@')[0] }}</p>
             <div><a href="{{ url_for('account.settings') }}">Settings</a></div>
             <div><a href="{{ url_for('auth.logout') }}">Logout</a></div>
+
         </div>
 
-        <nav class="side-nav" x-data="{so_header: false, set_so_true(){if (!this.so_header){this.so_header = true}}}">
+        <nav class="side-nav">
 
             <ul>
                 {% if "Attendee" in __roles__ %}
@@ -82,11 +115,11 @@
                 {% endif %}
             </ul>
 
-            <p class="m-up-3" x-cloak x-show="so_header"><strong>Staff Only</strong></p>
+            <p class="m-up-3" x-cloak x-show="staff_only_header"><strong>Staff Only</strong></p>
 
             <ul>
                 {% if "Proposal Reviewer" in __roles__ %}
-                    <li x-init="set_so_true()">
+                    <li x-init="set_staff_only_header_true()">
                         <a href="{{ url_for('staff_only.proposals.dashboard') }}"
                            {% if 'staff-only/proposals' in request.url %}class="selected"{% endif %}>
                             Proposals</a>
@@ -102,7 +135,7 @@
                 "Speaker Support Chair" in __roles__ or
                 "Sponsorship Chair" in __roles__ or
                 "Diversity Chair" in __roles__ %}
-                    <li x-init="set_so_true()">
+                    <li x-init="set_staff_only_header_true()">
                         <a href="{{ url_for('staff_only.conferences.index') }}"
                            {% if 'staff-only/conferences' in request.url %}class="selected"{% endif %}>
                             Conferences</a>
@@ -119,7 +152,7 @@
                     </li>
                 {% endif %}
                 {% if "Super Administrator" in __roles__ or "Administrator" in __roles__ %}
-                    <li x-init="set_so_true()">
+                    <li x-init="set_staff_only_header_true()">
                         <a href="{{ url_for('staff_only.system.dashboard') }}"
                            {% if 'staff-only/system' in request.url %}class="selected"{% endif %}>
                             System</a>
@@ -135,22 +168,18 @@
 
     </aside>
 
-    <div class="dummy-side-nav">
+    <div
+            class="dummy-side-nav"
+            x-cloak
+            x-show="!$store.backend_store.mobile_view"
+            :class="$store.backend_store.show_side_menu ? 'backend-menu-show' : 'backend-menu-hide'"
+    >
     </div>
 
     <section class="content">
-        <header>
-            <nav class="top-nav">
-                <div>
-                    {% block breadcrumbs %}{% endblock %}
-                </div>
-                <div>
-                    <a href="/">
-                        <img width="100px" src="{{ url_for('static', filename='flaskcon-logo.svg') }}" alt="">
-                    </a>
-                </div>
-            </nav>
-        </header>
+        <div class="breadcrumbs">
+            {% block breadcrumbs %}{% endblock %}
+        </div>
 
         <section>
             <div class="center-content">
@@ -163,6 +192,7 @@
 
 </div>
 
+{% include 'global/js/backend-x-data.html' %}
 {% block js %}
 {% endblock %}
 </body>

--- a/app/global/templates/global/js/backend-x-data.html
+++ b/app/global/templates/global/js/backend-x-data.html
@@ -1,0 +1,62 @@
+<script defer type="application/javascript">
+    document.addEventListener('alpine:init', () => {
+
+        let throttled = false;
+
+        Alpine.store('backend_store', {
+            show_side_menu: true,
+            mobile_view: false,
+            dummy_side_nav: true,
+            menu_clicks: 0,
+            init() {
+                if (window.innerWidth < 1000) {
+                    this.show_side_menu = false;
+                    this.mobile_view = true;
+                }
+            },
+            show_side_menu_true() {
+                this.show_side_menu = true;
+                this.menu_clicks++;
+            },
+            show_side_menu_false() {
+                this.show_side_menu = false;
+                this.menu_clicks++;
+            },
+        });
+
+        Alpine.data('backend', () => ({
+            staff_only_header: false,
+            set_staff_only_header_true() {
+                this.staff_only_header = true;
+            }
+        }));
+
+        function resizeFunc() {
+            if (window.innerWidth < 1000 && Alpine.store('backend_store').mobile_view === false) {
+                Alpine.store('backend_store').show_side_menu = false;
+                Alpine.store('backend_store').mobile_view = true;
+            }
+
+            if (window.innerWidth > 1000 && Alpine.store('backend_store').mobile_view === true) {
+                Alpine.store('backend_store').show_side_menu = true;
+                Alpine.store('backend_store').mobile_view = false;
+            }
+        }
+
+        function throttleResize() {
+            if (!throttled) {
+                throttled = true;
+                setTimeout(() => {
+                    throttled = false;
+                    resizeFunc();
+                }, 800);
+            }
+        }
+
+        onresize = () => {
+            throttleResize();
+        }
+
+    })
+
+</script>


### PR DESCRIPTION
Adjusted backend to have a header to accommodate for a side menu that hides and shows.

Created a side menu that hides and shows, and also reacts to window resizing for mobile view (this is being throttled in js)

Made the page title become the page header.

Edit: Also adjusted the breadcrumbs to be smaller, and the addition of `/` at the start to indicate more that it is breadcrumbs.

Menu open:

![image](https://github.com/FlaskCon/traveller-lite/assets/39418842/08d8bba9-d0c6-4e62-9e04-7e28ab81c5df)

Menu close:

![image](https://github.com/FlaskCon/traveller-lite/assets/39418842/fecfd954-6e81-44d0-b220-c2e6f357b470)

Mobile view closed:

![image](https://github.com/FlaskCon/traveller-lite/assets/39418842/c2d3be05-5992-4731-afee-293b7b092d5c)

Mobile view open:

![image](https://github.com/FlaskCon/traveller-lite/assets/39418842/68b914f9-b228-4c3f-8e4a-29ae559d4192)
